### PR TITLE
Improve performance 3-fold

### DIFF
--- a/dataclasses_json/core.py
+++ b/dataclasses_json/core.py
@@ -264,4 +264,4 @@ def _asdict(obj):
     elif isinstance(obj, Collection) and not isinstance(obj, str):
         return list(_asdict(v) for v in obj)
     else:
-        return copy.deepcopy(obj)
+        return obj

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='dataclasses_json',
-    version='1.0.7',
+    version='1.0.8',
     packages=['dataclasses_json'],
     include_package_data=True,
     description="Allows for easy dataclass parsing from/to JSON",


### PR DESCRIPTION
`zz.py`
```python
import pickle
import time

# I pickled one of my eventim_staging xpop responses
with open('adapter_response.pickle', 'rb') as f:
    adapter_response = pickle.load(f)

start = time.time()
print('start', start)
adapter_response.to_json()
end = time.time()
print('end', end)
print('∂', end - start)
```

### Before
```
~/src/eventim-adapter (master) % python3 zz.py
start 1574877578.4473221
end 1574877593.9543371
∂ 15.507014989852905
```

### After
```
~/src/eventim-adapter (master) % python3 zz.py
start 1574877821.45715
end 1574877825.82141
∂ 4.364259958267212
```

### Why was copy.deepcopy there
Because it was in the original dataclasses:
https://github.com/python/cpython/blob/793cb85437299a3da3d74fe65480d720af330cbb/Lib/dataclasses.py#L1094
I think the objcopy, is only there for if you are calling `dataclasses.asdict(some_dataclass_obj)` so that mutating the resulting dictionary does not mutate the original `some_dataclass_obj`.
For `to_json`, where it just calls `json.dumps` on this, this is completely redundant, since the resulting dict is disgarded and will never be mutated.

### Investigation
How I came about the idea of this change, profiling. This was the output of profiling that `to_json` call with `cProfile`.
Then calling `p.strip_dirs().sort_stats(SortKey.TIME).print_stats(10)`
```
Wed Nov 27 17:36:06 2019    to_json_profile.cProfile1

         89569431 function calls (72568221 primitive calls) in 30.822 seconds

   Ordered by: internal time
   List reduced from 87 to 10 due to restriction <10>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
13067621/769511   10.699    0.000   22.106    0.000 copy.py:132(deepcopy)
 23764619    2.368    0.000    2.368    0.000 {method 'get' of 'dict' objects}
    55845    1.701    0.000   19.072    0.000 copy.py:220(<listcomp>)
862607/12416    1.695    0.000   28.979    0.002 core.py:251(_asdict)
498432/37242    1.452    0.000   20.777    0.001 copy.py:268(_reconstruct)
 14508467    1.244    0.000    1.244    0.000 {built-in method builtins.id}
4662312/3036404    1.088    0.000    3.952    0.000 {built-in method builtins.isinstance}
  1625908    0.831    0.000    2.421    0.000 typing.py:713(__subclasscheck__)
  9453323    0.821    0.000    0.821    0.000 copy.py:190(_deepcopy_atomic)
166140/18615    0.751    0.000   20.152    0.001 copy.py:236(_deepcopy_dict)
```
we can see that a lot of time is being spent in `deepcopy`

### This is still fucking slow
Why?
Because `_asdict` is recursive, and is called inside `_override` which also recursively calls itself after calling `_asdict`.
Fuck me!
So, we can sort that out in another PR I think. Either by changing `_override` to somehow call itself before `_asdict`, or remove recursiveness from `_asdict`.