### PR TITLE
another 3-fold perf improvement

### DIFF
--- a/dataclasses_json/core.py
+++ b/dataclasses_json/core.py
@@ -256,11 +256,11 @@ def _asdict(obj):
     if _is_dataclass_instance(obj):
         result = []
         for f in fields(obj):
-            value = _asdict(getattr(obj, f.name))
+            value = getattr(obj, f.name)
             result.append((f.name, value))
         return dict(result)
     elif isinstance(obj, Mapping):
-        return dict((_asdict(k), _asdict(v)) for k, v in obj.items())
+        return dict((_asdict(k), v) for k, v in obj.items())
     elif isinstance(obj, Collection) and not isinstance(obj, str):
         return list(_asdict(v) for v in obj)
     else:

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='dataclasses_json',
-    version='1.0.8',
+    version='1.0.9',
     packages=['dataclasses_json'],
     include_package_data=True,
     description="Allows for easy dataclass parsing from/to JSON",


### PR DESCRIPTION
This gets rid of a lot of the unnecessary recursive calls.
Following on from #6 and running the same benchmark:
```
~/src/eventim-adapter (master) % python zz.py
start 1574951780.4001222
end 1574951781.779072
∂ 1.3789498805999756
```

Basically, in `_override`, if `_asdict` returns a dictionary, `_overrides` is going to loop through all the fields and call `_override`, which calls `_asdict`. So, for the cases where `_asdict` is returning a dict, we don't need it 