### PR TITLE
allow forward references

### DIFF
--- a/tests/test_recursive.py
+++ b/tests/test_recursive.py
@@ -1,8 +1,6 @@
 from dataclasses import dataclass
 from typing import Optional
 
-import pytest
-
 from dataclasses_json import DataClassJsonMixin
 
 
@@ -76,10 +74,8 @@ family_tree = Tree(
 
 
 class TestRecursive:
-    @pytest.mark.skip(msg="feature incomplete")
     def test_tree_encode(self):
         assert family_tree.to_json(indent=4) == family_tree_json
 
-    @pytest.mark.skip(msg="feature incomplete")
     def test_tree_decode(self):
         assert Tree.from_json(family_tree_json) == family_tree


### PR DESCRIPTION
This allows us to use classes with strings for type, e.g.
```
class B:
  x: 'A'

class A:
  pass
```
or use ```from __future__ import annotations```

ported issue 77 from original lib